### PR TITLE
Add Self Hosted GKE Runners for cdapio/hub repository

### DIFF
--- a/hub-cdapio/Dockerfile
+++ b/hub-cdapio/Dockerfile
@@ -1,0 +1,67 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Specifying base image as Ubuntu 20.04 LTS
+FROM ubuntu:20.04
+
+# Installing necessary tools and packages in non user interactive automated mode
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    echo LANG=C.UTF-8 > /etc/default/locale && \
+    apt-get update && \
+    apt-get -y install curl \
+    iputils-ping \
+    tar \
+    jq \
+    python \
+    python3 \
+    python3-pip \
+    openjdk-8-jdk-headless \
+    gnupg \
+    git \
+    wget \
+    nodejs \
+    maven && \
+    update-java-alternatives -s java-1.8.0-openjdk-amd64 && \
+    wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 && \
+    chmod a+x /usr/local/bin/yq
+
+
+# Specifying GitHub Runner Version
+ARG GH_RUNNER_VERSION="2.292.0"
+WORKDIR /runner
+
+
+# Installing GitHub Runner Application on the Docker Image
+RUN curl -o actions.tar.gz --location "https://github.com/actions/runner/releases/download/v${GH_RUNNER_VERSION}/actions-runner-linux-x64-${GH_RUNNER_VERSION}.tar.gz" && \
+    tar -zxf actions.tar.gz && \
+    rm -f actions.tar.gz && \
+    /runner/bin/installdependencies.sh
+
+COPY entrypoint.sh /runner
+RUN chmod +x entrypoint.sh && \
+    groupadd -r runner && useradd -r -g runner runner && \
+    mkdir /home/runner && \
+    chown -R runner:runner /runner && \
+    chown -R runner:runner /home/runner
+USER runner
+
+# Installing Google Cloud SDK and YAML querying tools under 'runner' user
+RUN curl -sSL https://sdk.cloud.google.com | bash
+ENV PATH $PATH:/home/runner/google-cloud-sdk/bin
+RUN pip3 install yaml-query
+RUN pip3 install pyyaml
+RUN pip3 install google-cloud-storage
+
+# Initiating entrypoint with script for authorising registration of GitHub Runner
+ENTRYPOINT ["/runner/entrypoint.sh"]

--- a/hub-cdapio/entrypoint.sh
+++ b/hub-cdapio/entrypoint.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Formatting URL for GitHub API for creation of registration token for an organization
+registration_url="https://api.github.com/orgs/${ORG_NAME}/actions/runners/registration-token"
+echo "Requesting registration URL at '${registration_url}'"
+
+# Making POST Request to GitHub API along with token header using curl
+payload=$(curl -sX POST -H "Authorization: token ${GITHUB_TOKEN}" ${registration_url})
+export RUNNER_TOKEN=$(echo $payload | jq .token --raw-output)
+
+# Creating an configuring self hosted runner
+/runner/config.sh --name $(hostname) --token ${RUNNER_TOKEN} --url https://github.com/${ORG_NAME} --work ${RUNNER_WORKDIR} --unattended --replace --ephemeral --labels ${RUNNER_LABEL}
+
+remove() {
+	    /runner/config.sh remove --unattended --token "${RUNNER_TOKEN}"
+    }
+
+# Error handled exits
+trap 'remove; exit 130' INT
+trap 'remove; exit 143' TERM
+
+/runner/bin/runsvc.sh "$@" &
+
+wait $!

--- a/hub-cdapio/kustomization.yaml
+++ b/hub-cdapio/kustomization.yaml
@@ -1,0 +1,50 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+nameSuffix: -hub-cdapio
+commonLabels:
+  type: hub
+  org: cdapio
+bases:
+  - ../build
+images:
+  - name: gcr.io/cdapio-github-builds/runner:latest
+    newName: gcr.io/cdapio-github-builds/runner-hub
+patches:
+  - patch: |-
+      - op: add
+        path: "/spec/template/spec/serviceAccountName"
+        value: gke-github-runner-hub-sa
+      - op: add
+        path: "/spec/template/spec/imagePullPolicy"
+        value: true
+    target:
+      kind: Deployment
+  - patch: |-
+      - op: replace
+        path: "/spec/maxReplicas"
+        value: 5
+      - op: replace
+        path: "/spec/minReplicas"
+        value: 5
+    target:
+      kind: HorizontalPodAutoscaler
+configMapGenerator:
+  - literals:
+    - ORG_NAME=cdapio
+    - RUNNER_LABEL=cdapio-hub-k8-runner
+    name: runner-k8s-config
+    behavior: merge


### PR DESCRIPTION
Added Docker Image and entrypoint files for self hosted GKE runner for the cdapio/hub repository. The image has necessary tools and packages, including Google Cloud SDK needed for CI/CD automation workflows in the Hub repository.

Further, appended commands for using the above runner in the README file, and updated other commands (wherever needed) as per new requirements.
Added an additional header image to the README to prettify as well.

The Docker Images and deployments shall be deployed in appropriate CDAP GCP Project after merging this PR, and thereby followed by enabling these runners in the Hub repository.